### PR TITLE
Use asyncbigtable repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-ENV TSDB_VERSION=2.3.0 \
+ENV TSDB_VERSION=2.4.0RC2 \
     DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qq update \
@@ -8,10 +8,16 @@ RUN apt-get -qq update \
  && rm -rf /var/lib/apt/lists/* \
  && mkdir -p /opt/opentsdb
 
+COPY files/*.jar files/include.mk /opt/opentsdb/
+
 WORKDIR /opt/opentsdb
 
-RUN git clone --quiet --depth 1 https://github.com/goll/opentsdb.git opentsdb-${TSDB_VERSION} \
+RUN git clone --quiet --depth 1 --branch v2.4.0RC2 https://github.com/OpenTSDB/opentsdb.git opentsdb-${TSDB_VERSION} \
  && cd opentsdb-${TSDB_VERSION} \
+ && mv /opt/opentsdb/include.mk third_party/asyncbigtable/include.mk \
+ && mv /opt/opentsdb/*.jar third_party/asyncbigtable/ \
+ && sed -i '/ASYNCBIGTABLE_VERSION/a\
+          <systemPath>@ASYNCBIGTABLE_FILE_LOCATION@</systemPath>' pom.xml.in \
  && bash build-bigtable.sh \
  && ln -s /opt/opentsdb/opentsdb-${TSDB_VERSION}/build/tsdb /usr/bin/tsdb \
  && ln -s /opt/opentsdb/opentsdb-${TSDB_VERSION}/build/staticroot /opt/opentsdb/staticroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,26 @@
-FROM ubuntu:16.04
+FROM debian:stretch-slim
 
-ENV TSDB_VERSION=2.4.0RC2 \
-    DEBIAN_FRONTEND=noninteractive
+ENV TSDB_VERSION=2.4.0 \
+    PATH="${PATH}:/opt/opentsdb/opentsdb-2.4.0/build"
 
-RUN apt-get -qq update \
- && apt-get -qq --no-install-recommends install git autoconf automake gawk openjdk-8-jdk-headless curl make python gnuplot5-nox \
- && rm -rf /var/lib/apt/lists/* \
- && mkdir -p /opt/opentsdb
+RUN mkdir -p /opt/opentsdb /usr/share/man/man1 \
+ && apt-get -qq update \
+ && DEBIAN_FRONTEND=noninteractive apt-get -qq --no-install-recommends install git autoconf automake gawk openjdk-8-jdk-headless curl make python gnuplot-nox \
+ && rm -rf /var/lib/apt/lists/*
 
-COPY files/*.jar files/include.mk /opt/opentsdb/
+COPY files/* /opt/opentsdb/
 
 WORKDIR /opt/opentsdb
 
-RUN git clone --quiet --depth 1 --branch v2.4.0RC2 https://github.com/OpenTSDB/opentsdb.git opentsdb-${TSDB_VERSION} \
+RUN git clone --quiet --depth 1 --branch v2.4.0 https://github.com/OpenTSDB/opentsdb.git opentsdb-${TSDB_VERSION} \
  && cd opentsdb-${TSDB_VERSION} \
  && mv /opt/opentsdb/include.mk third_party/asyncbigtable/include.mk \
- && mv /opt/opentsdb/*.jar third_party/asyncbigtable/ \
- && sed -i '/ASYNCBIGTABLE_VERSION/a\
-          <systemPath>@ASYNCBIGTABLE_FILE_LOCATION@</systemPath>' pom.xml.in \
+ && mv /opt/opentsdb/*.md5 third_party/asyncbigtable/ \
  && bash build-bigtable.sh \
- && ln -s /opt/opentsdb/opentsdb-${TSDB_VERSION}/build/tsdb /usr/bin/tsdb \
  && ln -s /opt/opentsdb/opentsdb-${TSDB_VERSION}/build/staticroot /opt/opentsdb/staticroot
 
 COPY files/opentsdb.conf files/bigtable.json /opt/opentsdb/
 
 EXPOSE 4242
 
-ENTRYPOINT ["/usr/bin/tsdb", "tsd", "--config=/opt/opentsdb/opentsdb.conf"]
+ENTRYPOINT ["tsdb", "tsd", "--config=/opt/opentsdb/opentsdb.conf"]

--- a/README.md
+++ b/README.md
@@ -2,12 +2,19 @@
 Docker image that builds OpenTSDB using Bigtable with latest asyncbigtable.
 
 * Base image used is `ubuntu:16.04`
-* Using the latest released asyncbigtable [0.3.0](https://github.com/OpenTSDB/asyncbigtable/releases/tag/v0.3.0)
-* OpenTSDB 2.3.0 built from forked [repository](https://github.com/goll/opentsdb) with updated asyncbigtable
+* Using latest asyncbigtable built from official [repository](https://github.com/OpenTSDB/asyncbigtable) with:
+```
+<dependency>
+  <groupId>com.google.cloud.bigtable</groupId>
+  <artifactId>bigtable-hbase-2.x</artifactId>
+  <version>1.3.0</version>
+</dependency>
+```
+* OpenTSDB 2.4.0RC2 built from official [repository](https://github.com/OpenTSDB/opentsdb/releases/tag/v2.4.0RC2)
 
 ## Configuration
 * Replace the placeholder [bigtable.json](files/bigtable.json) with a valid service account JSON key file
-* Set the correct `google.bigtable.*` values in [opentsdb.conf](files/opentsdb.conf#L116-L120)
+* Set the correct `google.bigtable.*` values in [opentsdb.conf](files/opentsdb.conf#L115-L132)
 * Most of the options in [opentsdb.conf](files/opentsdb.conf) are set to defaults, change them to fit your needs
 
 ## Create the service account key file

--- a/README.md
+++ b/README.md
@@ -1,16 +1,9 @@
 # opentsdb-bigtable
 Docker image that builds OpenTSDB using Bigtable with latest asyncbigtable.
 
-* Base image used is `ubuntu:16.04`
-* Using latest asyncbigtable built from official [repository](https://github.com/OpenTSDB/asyncbigtable) with:
-```
-<dependency>
-  <groupId>com.google.cloud.bigtable</groupId>
-  <artifactId>bigtable-hbase-2.x</artifactId>
-  <version>1.3.0</version>
-</dependency>
-```
-* OpenTSDB 2.4.0RC2 built from official [repository](https://github.com/OpenTSDB/opentsdb/releases/tag/v2.4.0RC2)
+* Base image used is `debian:stretch-slim`
+* Using latest asyncbigtable from official [repository](https://oss.sonatype.org/content/repositories/snapshots/com/pythian/opentsdb/asyncbigtable/0.4.1-SNAPSHOT/)
+* OpenTSDB 2.4.0 built from official [repository](https://github.com/OpenTSDB/opentsdb/releases/tag/v2.4.0)
 
 ## Configuration
 * Replace the placeholder [bigtable.json](files/bigtable.json) with a valid service account JSON key file
@@ -27,6 +20,6 @@ $ gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:
 
 ## Build the image
 ```
-$ docker pull ubuntu:16.04
+$ docker pull debian:stretch-slim
 $ docker build -t opentsdb-bigtable:foobar .
 ```

--- a/files/asyncbigtable-0.4.1-20190108.232311-2-jar-with-dependencies.jar.md5
+++ b/files/asyncbigtable-0.4.1-20190108.232311-2-jar-with-dependencies.jar.md5
@@ -1,0 +1,1 @@
+7831941ed72cb187fca2ca8a2df1eb68

--- a/files/include.mk
+++ b/files/include.mk
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-ASYNCBIGTABLE_VERSION := 0.3.0
+ASYNCBIGTABLE_VERSION := 0.3.1-SNAPSHOT
 ASYNCBIGTABLE := third_party/asyncbigtable/asyncbigtable-$(ASYNCBIGTABLE_VERSION)-jar-with-dependencies.jar
 ASYNCBIGTABLE_FILE_LOCATION := third_party/asyncbigtable/asyncbigtable-$(ASYNCBIGTABLE_VERSION)-jar-with-dependencies.jar
 

--- a/files/include.mk
+++ b/files/include.mk
@@ -13,8 +13,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-ASYNCBIGTABLE_VERSION := 0.3.1-SNAPSHOT
+ASYNCBIGTABLE_VERSION := 0.4.1-20190108.232311-2
 ASYNCBIGTABLE := third_party/asyncbigtable/asyncbigtable-$(ASYNCBIGTABLE_VERSION)-jar-with-dependencies.jar
-ASYNCBIGTABLE_FILE_LOCATION := third_party/asyncbigtable/asyncbigtable-$(ASYNCBIGTABLE_VERSION)-jar-with-dependencies.jar
+ASYNCBIGTABLE_BASE_URL := https://oss.sonatype.org/content/repositories/snapshots/com/pythian/opentsdb/asyncbigtable/0.4.1-SNAPSHOT/
+
+$(ASYNCBIGTABLE): $(ASYNCBIGTABLE).md5
+	set dummy "$(ASYNCBIGTABLE_BASE_URL)" "$(ASYNCBIGTABLE)"; shift; $(FETCH_DEPENDENCY)
 
 THIRD_PARTY += $(ASYNCBIGTABLE)

--- a/files/opentsdb.conf
+++ b/files/opentsdb.conf
@@ -119,9 +119,6 @@ google.bigtable.project.id = PROJECT-ID
 # Bigtable instance ID
 google.bigtable.instance.id = INSTANCE-ID
 
-# The class that will be used to implement the HBase API AsyncBigtable will use as a shim between the Bigtable client and OpenTSDB
-hbase.client.connection.impl = com.google.cloud.bigtable.hbase1_2.BigtableConnection
-
 # Whether or not to use a Google cloud service account to connect
 # Set this to true
 google.bigtable.auth.service.account.enable = true


### PR DESCRIPTION
Switches the base image to debian:stretch-slim, uses the official asyncbigtable repository to pull latest jar.